### PR TITLE
Bytes support

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -84,7 +84,7 @@ var wellKnownTypes = map[string]string{
 	"UInt32Value": "*uint32",
 	"UInt64Value": "*uint64",
 	"BoolValue":   "*bool",
-	"BytesValue" : "*[]byte",
+	// "BytesValue" : "*[]byte",
 }
 
 const (
@@ -903,7 +903,7 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 					fieldType = "*string"
 				case "smallint", "integer", "bigint", "numeric", "smallserial", "serial", "bigserial":
 					fieldType = "*int64"
-				case "jsonb", "bytea":
+				case "jsonb", "bytea", "bytes":
 					fieldType = "[]byte"
 				case "":
 					fieldType = "interface{}" // we do not know the type yet (if it association we will fix the type later)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -936,6 +936,8 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 			fieldType = "float32"
 		case "double":
 			fieldType = "float64"
+		case "bytes":
+			fieldType = "[]byte"
 		}
 
 		f := &Field{

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -84,7 +84,7 @@ var wellKnownTypes = map[string]string{
 	"UInt32Value": "*uint32",
 	"UInt64Value": "*uint64",
 	"BoolValue":   "*bool",
-	// "BytesValue" : "*[]byte",
+	//  "BytesValue" : "*[]byte",
 }
 
 const (

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -903,7 +903,7 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 					fieldType = "*string"
 				case "smallint", "integer", "bigint", "numeric", "smallserial", "serial", "bigserial":
 					fieldType = "*int64"
-				case "jsonb", "bytea", "bytes":
+				case "jsonb", "bytea":
 					fieldType = "[]byte"
 				case "":
 					fieldType = "interface{}" // we do not know the type yet (if it association we will fix the type later)
@@ -989,6 +989,9 @@ func (b *ORMBuilder) addIncludedField(ormable *OrmableType, field *gorm.ExtraFie
 		// Handle types without a package defined
 		if _, ok := builtinTypes[rawType]; ok {
 			// basic type, 100% okay, no imports or changes needed
+			if rawType == "bytes" {
+				rawType = "[]byte"
+			}
 		} else if rawType == "Time" {
 			// b.UsingGoImports(stdTimeImport) // TODO: missing UsingGoImports
 			rawType = generateImport("Time", stdTimeImport, g)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
+	gorm "github.com/circadence-official/protoc-gen-gorm/options"
 	jgorm "github.com/jinzhu/gorm"
 	"github.com/jinzhu/inflection"
-	gorm "github.com/circadence-official/protoc-gen-gorm/options"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -84,7 +84,7 @@ var wellKnownTypes = map[string]string{
 	"UInt32Value": "*uint32",
 	"UInt64Value": "*uint64",
 	"BoolValue":   "*bool",
-	//  "BytesValue" : "*[]byte",
+	"BytesValue" : "*[]byte",
 }
 
 const (

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -73,7 +73,6 @@ var builtinTypes = map[string]struct{}{
 	"float64": {},
 	"string":  {},
 	"[]byte":  {},
-	"bytes":  {},
 }
 
 var wellKnownTypes = map[string]string{
@@ -904,7 +903,7 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 					fieldType = "*string"
 				case "smallint", "integer", "bigint", "numeric", "smallserial", "serial", "bigserial":
 					fieldType = "*int64"
-				case "jsonb", "bytea", "bytes":
+				case "jsonb", "bytea":
 					fieldType = "[]byte"
 				case "":
 					fieldType = "interface{}" // we do not know the type yet (if it association we will fix the type later)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -84,7 +84,7 @@ var wellKnownTypes = map[string]string{
 	"UInt32Value": "*uint32",
 	"UInt64Value": "*uint64",
 	"BoolValue":   "*bool",
-	// "BytesValue" : "*[]byte",
+	"bytes":       "[]byte",
 }
 
 const (
@@ -989,9 +989,6 @@ func (b *ORMBuilder) addIncludedField(ormable *OrmableType, field *gorm.ExtraFie
 		// Handle types without a package defined
 		if _, ok := builtinTypes[rawType]; ok {
 			// basic type, 100% okay, no imports or changes needed
-			if rawType == "bytes" {
-				rawType = "[]byte"
-			}
 		} else if rawType == "Time" {
 			// b.UsingGoImports(stdTimeImport) // TODO: missing UsingGoImports
 			rawType = generateImport("Time", stdTimeImport, g)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -73,6 +73,7 @@ var builtinTypes = map[string]struct{}{
 	"float64": {},
 	"string":  {},
 	"[]byte":  {},
+	"bytes":  {},
 }
 
 var wellKnownTypes = map[string]string{
@@ -84,7 +85,7 @@ var wellKnownTypes = map[string]string{
 	"UInt32Value": "*uint32",
 	"UInt64Value": "*uint64",
 	"BoolValue":   "*bool",
-	"bytes":       "[]byte",
+	// "BytesValue" : "*[]byte",
 }
 
 const (
@@ -903,7 +904,7 @@ func (b *ORMBuilder) parseBasicFields(msg *protogen.Message, g *protogen.Generat
 					fieldType = "*string"
 				case "smallint", "integer", "bigint", "numeric", "smallserial", "serial", "bigserial":
 					fieldType = "*int64"
-				case "jsonb", "bytea":
+				case "jsonb", "bytea", "bytes":
 					fieldType = "[]byte"
 				case "":
 					fieldType = "interface{}" // we do not know the type yet (if it association we will fix the type later)


### PR DESCRIPTION
This PR makes it so that the plugin will properly map a proto `bytes` type to a Go `[]byte` type (byte array/slice). This also works in Postgres to create `bytea` columns. Previously, given the below `.proto`:

```proto
bytes zip= 12 [(gorm.field).tag = {type: "bytes"}];
```

Would produce the following (invalid) Go code:

```go
Zip bytes `gorm:"type:bytes"`
```

This is invalid because `bytes` is not a Go type. It should be `[]bytes`. After this PR the generated code is as follows:

```go
Zip []byte `gorm:"type:bytes"`
```

Which is valid Go.